### PR TITLE
Require rspec and rack-test only in the test environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,7 @@
 source :rubygems
 gem 'sinatra', '>= 1.0'
 gem 'rake'
-gem 'rspec', :require => 'spec'
 gem 'data_mapper'
-gem 'rack-test'
 gem 'dm-core'
 gem 'dm-sqlite-adapter'
 gem 'dm-timestamps'
@@ -11,3 +9,8 @@ gem 'dm-validations'
 gem 'dm-aggregates'
 gem 'dm-migrations'
 gem 'haml'
+
+group :test do
+  gem 'rspec', :require => 'spec'
+  gem 'rack-test'
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'rubygems'
-require 'bundler/setup'
+require 'bundler'
+Bundler.setup(:default, :test)
 require 'sinatra'
 require 'rspec'
 require 'rack/test'


### PR DESCRIPTION
Currently the rspec and rack-test were loaded even in the development and production environment, this commit fixes the the problem using `Bundler.setup(:default, :test)` instead of `require 'bundler/setup'`
